### PR TITLE
Fix: Enable package execution via npx

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@onigeya/siyuan-mcp-server",
-  "version": "1.2.3",
+  "name": "@huia/siyuan-mcp-server",
+  "version": "1.2.5",
   "description": "思源笔记MCP服务器",
   "bin": {
     "siyuan-mcp-server": "./dist/server.js"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@huia/siyuan-mcp-server",
+  "name": "@onigeya/siyuan-mcp-server",
   "version": "1.2.5",
   "description": "思源笔记MCP服务器",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "@onigeya/siyuan-mcp-server",
   "version": "1.2.3",
   "description": "思源笔记MCP服务器",
+  "bin": {
+    "siyuan-mcp-server": "./dist/server.js"
+  },
   "type": "module",
   "private": false,
   "main": "./dist/server.js",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { registerCommandTool } from './tools/commands.js';


### PR DESCRIPTION
 @onigeya 你好,
非常感谢你开发这个优秀的项目！
在按照 README.md 文档中的说明，使用 npx @onigeya/siyuan-mcp-server 配置Cursor或者运行命令时，会遇到 could not determine executable to run 或 command not found 的错误。
经过一番调试后，我发现是包的配置缺少了让 npx 正确执行所需要的两个关键部分：
1. 在 package.json 中添加了 bin 字段：这会告诉 npx 当调用这个包时，应该执行哪一个脚本文件。
2. 在 src/server.ts 文件顶部添加了 Shebang (#!/usr/bin/env node)：这确保了编译后的 dist/server.js 文件能被操作系统识别为一个 Node.js 可执行文件，解决了 command not found 的问题。
希望能对项目有所帮助！